### PR TITLE
Grab the correct dragelement

### DIFF
--- a/inst/www/dragndrop.js
+++ b/inst/www/dragndrop.js
@@ -1,13 +1,23 @@
+// need to bind on inserted to work with insertUI
 $(document).bind('DOMNodeInserted', function(){
   $(".dropelement").on("dragover",function(e){
     e.preventDefault();
   });
   $(".dragelement").on("dragstart",function(e){
-    e.originalEvent.dataTransfer.setData("Text",e.target.id);
+    var nodeCheck = e.target;
+    var dragName = nodeCheck.id;
+    
+    // make sure you grab the entire draggable element
+    while(dragName === "" || nodeCheck.className !== "dragelement") {
+      nodeCheck = nodeCheck.parentNode;
+      dragName = nodeCheck.id;
+    }
+    e.originalEvent.dataTransfer.setData("Text",dragName);
   });
   $(".dropelement").on("drop",function(e){
     e.preventDefault();
     var data=e.originalEvent.dataTransfer.getData("Text");
+    // prevent images from stacking on tope of each other
     if (e.target.nodeName !== "IMG") {
       e.target.appendChild(document.getElementById(data));
       var el = $(e.target);


### PR DESCRIPTION
The nested e.target.id can cause issues so you need to check the correct parentNode.id to drop.
